### PR TITLE
Update Flutter SDK constraints

### DIFF
--- a/show_platform_date_picker/pubspec.yaml
+++ b/show_platform_date_picker/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/tinoper/show_platform_date_picker/tree/main/show_
 issue_tracker: https://github.com/tinoper/show_platform_date_picker/issues
 
 environment:
-  sdk: '>=2.18.6 <3.0.0'
-  flutter: ">=1.17.0"
+  sdk: '^3.8.0'
+  flutter: ">=3.32.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- update `pubspec.yaml` to require Flutter 3.32 and Dart 3.8

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68701d0361bc8324b3f262d9e4a0cc1e